### PR TITLE
Remove redundancies to shorten the script length.

### DIFF
--- a/acme_tiny.py
+++ b/acme_tiny.py
@@ -17,16 +17,21 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     def _b64(b):
         return base64.urlsafe_b64encode(b).decode('utf8').replace("=", "")
 
+    # helper function run openssl subprocess
+    def _openssl(command, options, communicate=None):
+        openssl = subprocess.Popen(["openssl", command] + options,
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = openssl.communicate(communicate)
+        if openssl.returncode != 0:
+            raise IOError("OpenSSL Error: {0}".format(err))
+        return out
+
     # parse account key to get public key
     log.info("Parsing account key...")
-    proc = subprocess.Popen(["openssl", "rsa", "-in", account_key, "-noout", "-text"],
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = proc.communicate()
-    if proc.returncode != 0:
-        raise IOError("OpenSSL Error: {0}".format(err))
     pub_hex, pub_exp = re.search(
         r"modulus:\n\s+00:([a-f0-9\:\s]+?)\npublicExponent: ([0-9]+)",
-        out.decode('utf8'), re.MULTILINE|re.DOTALL).groups()
+        _openssl("rsa", ["-in", account_key, "-noout", "-text"]).decode('utf8'),
+        re.MULTILINE|re.DOTALL).groups()
     pub_exp = "{0:x}".format(int(pub_exp))
     pub_exp = "0{0}".format(pub_exp) if len(pub_exp) % 2 else pub_exp
     header = {
@@ -41,38 +46,38 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
     thumbprint = _b64(hashlib.sha256(accountkey_json.encode('utf8')).digest())
 
     # helper function make signed requests
-    def _send_signed_request(url, payload):
+    def _send_signed_request(url, payload, return_codes, error_message):
         payload64 = _b64(json.dumps(payload).encode('utf8'))
         protected = copy.deepcopy(header)
         protected["nonce"] = urlopen(CA + "/directory").headers['Replay-Nonce']
         protected64 = _b64(json.dumps(protected).encode('utf8'))
-        proc = subprocess.Popen(["openssl", "dgst", "-sha256", "-sign", account_key],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        out, err = proc.communicate("{0}.{1}".format(protected64, payload64).encode('utf8'))
-        if proc.returncode != 0:
-            raise IOError("OpenSSL Error: {0}".format(err))
-        data = json.dumps({
-            "header": header, "protected": protected64,
-            "payload": payload64, "signature": _b64(out),
+        signed_request = json.dumps({
+            "header": header, "protected": protected64, "payload": payload64,
+            "signature": _b64(_openssl("dgst", ["-sha256", "-sign", account_key],
+                communicate="{0}.{1}".format(protected64, payload64).encode("utf8")))
         })
         try:
-            resp = urlopen(url, data.encode('utf8'))
-            return resp.getcode(), resp.read()
+            resp = urlopen(url, signed_request.encode("utf8"))
+            code, result = resp.getcode(), resp.read()
         except IOError as e:
-            return getattr(e, "code", None), getattr(e, "read", e.__str__)()
+            code, result = getattr(e, "code", None), getattr(e, "read", e.reason.__str__)()
+        finally:
+            try:
+                message = return_codes[code]
+                if message is not None:
+                    log.info(message)
+                return result
+            except KeyError:
+                raise ValueError(error_message.format(code=code, result=result))
 
     # find domains
     log.info("Parsing CSR...")
-    proc = subprocess.Popen(["openssl", "req", "-in", csr, "-noout", "-text"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    out, err = proc.communicate()
-    if proc.returncode != 0:
-        raise IOError("Error loading {0}: {1}".format(csr, err))
+    csr_dump = _openssl("req", ["-in", csr, "-noout", "-text"]).decode("utf8")
     domains = set([])
-    common_name = re.search(r"Subject:.*? CN=([^\s,;/]+)", out.decode('utf8'))
+    common_name = re.search(r"Subject:.*? CN=([^\s,;/]+)", csr_dump)
     if common_name is not None:
         domains.add(common_name.group(1))
-    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", out.decode('utf8'), re.MULTILINE|re.DOTALL)
+    subject_alt_names = re.search(r"X509v3 Subject Alternative Name: \n +([^\n]+)\n", csr_dump, re.MULTILINE|re.DOTALL)
     if subject_alt_names is not None:
         for san in subject_alt_names.group(1).split(", "):
             if san.startswith("DNS:"):
@@ -80,28 +85,18 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
 
     # get the certificate domains and expiration
     log.info("Registering account...")
-    code, result = _send_signed_request(CA + "/acme/new-reg", {
-        "resource": "new-reg",
-        "agreement": "https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf",
-    })
-    if code == 201:
-        log.info("Registered!")
-    elif code == 409:
-        log.info("Already registered!")
-    else:
-        raise ValueError("Error registering: {0} {1}".format(code, result))
+    _send_signed_request(CA + "/acme/new-reg",
+        {"resource": "new-reg", "agreement": "https://letsencrypt.org/documents/LE-SA-v1.0.1-July-27-2015.pdf"},
+        {201: "Registered!", 409: "Already registered!"}, "Error registering: {code} {result}")
 
     # verify each domain
     for domain in domains:
         log.info("Verifying {0}...".format(domain))
 
         # get new challenge
-        code, result = _send_signed_request(CA + "/acme/new-authz", {
-            "resource": "new-authz",
-            "identifier": {"type": "dns", "value": domain},
-        })
-        if code != 201:
-            raise ValueError("Error requesting challenges: {0} {1}".format(code, result))
+        result = _send_signed_request(CA + "/acme/new-authz",
+            {"resource": "new-authz", "identifier": {"type": "dns", "value": domain}},
+            {201: None}, "Error requesting challenges: {code} {result}")
 
         # make the challenge file
         challenge = [c for c in json.loads(result.decode('utf8'))['challenges'] if c['type'] == "http-01"][0]
@@ -123,12 +118,9 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
                 wellknown_path, wellknown_url))
 
         # notify challenge are met
-        code, result = _send_signed_request(challenge['uri'], {
-            "resource": "challenge",
-            "keyAuthorization": keyauthorization,
-        })
-        if code != 202:
-            raise ValueError("Error triggering challenge: {0} {1}".format(code, result))
+        _send_signed_request(challenge['uri'],
+            {"resource": "challenge", "keyAuthorization": keyauthorization},
+            {202: None}, "Error triggering challenge: {code} {result}")
 
         # wait for challenge to be verified
         while True:
@@ -150,15 +142,9 @@ def get_crt(account_key, csr, acme_dir, log=LOGGER, CA=DEFAULT_CA):
 
     # get the new certificate
     log.info("Signing certificate...")
-    proc = subprocess.Popen(["openssl", "req", "-in", csr, "-outform", "DER"],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    csr_der, err = proc.communicate()
-    code, result = _send_signed_request(CA + "/acme/new-cert", {
-        "resource": "new-cert",
-        "csr": _b64(csr_der),
-    })
-    if code != 201:
-        raise ValueError("Error signing certificate: {0} {1}".format(code, result))
+    result = _send_signed_request(CA + "/acme/new-cert",
+        {"resource": "new-cert", "csr": _b64(_openssl("req", ["-in", csr, "-outform", "DER"]))},
+        {201: None}, "Error signing certificate: {code} {result}")
 
     # return signed certificate!
     log.info("Certificate signed!")


### PR DESCRIPTION
Create _openssl helper function to run openssl subprocesses.
Modify _send_signed_request helper function combine duplicate code.
Various formatting changes to take further advantage of reduced redundancy.